### PR TITLE
Weak themes advice interval

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -39,6 +39,7 @@ class BotSettings(BaseSettings):
     MAX_QUESTION_PER_DAY: int = 3
     DELAY_AFTER_ACHIEVEMENT: int = 3
     SUBSCRIPTION_PRICE: int = 899
+    WEAK_THEMES_ADVICE_INTERVAL = 30
 
     class Config:
         case_sensitive = False

--- a/settings.py
+++ b/settings.py
@@ -39,7 +39,7 @@ class BotSettings(BaseSettings):
     MAX_QUESTION_PER_DAY: int = 3
     DELAY_AFTER_ACHIEVEMENT: int = 3
     SUBSCRIPTION_PRICE: int = 899
-    WEAK_THEMES_ADVICE_INTERVAL = 30
+    WEAK_THEMES_ADVICE_INTERVAL: int = 30
 
     class Config:
         case_sensitive = False

--- a/src/repositories/postgres/advices.py
+++ b/src/repositories/postgres/advices.py
@@ -97,7 +97,7 @@ class AdvicesRepo:
                 WHERE
                   user_id = $1
                 AND
-                  created_at BETWEEN CURRENT_DATE - $2 AND CURRENT_DATE
+                  created_at (BETWEEN CURRENT_DATE - $2)::date AND CURRENT_DATE
                 AND
                   theme = $3
                 AND

--- a/src/repositories/postgres/advices.py
+++ b/src/repositories/postgres/advices.py
@@ -97,7 +97,7 @@ class AdvicesRepo:
                 WHERE
                   user_id = $1
                 AND
-                  created_at (BETWEEN CURRENT_DATE - $2)::date AND CURRENT_DATE
+                  created_at (BETWEEN CURRENT_DATE - $2) AND CURRENT_DATE
                 AND
                   theme = $3
                 AND

--- a/src/repositories/postgres/advices.py
+++ b/src/repositories/postgres/advices.py
@@ -1,4 +1,5 @@
 import asyncpg
+
 from settings import bot_settings
 
 

--- a/src/repositories/postgres/advices.py
+++ b/src/repositories/postgres/advices.py
@@ -86,7 +86,7 @@ class AdvicesRepo:
     async def get_send_advice(self, user_id: int, theme: str, level: int) -> asyncpg.Record | None:
         async with self.pg_pool.acquire() as conn:
             row = await conn.fetchrow(
-                f"""
+                """
                 SELECT
                   id
                 FROM
@@ -96,13 +96,14 @@ class AdvicesRepo:
                 WHERE
                   user_id = $1
                 AND
-                  created_at BETWEEN CURRENT_DATE - {bot_settings.WEAK_THEMES_ADVICE_INTERVAL} AND CURRENT_DATE
+                  created_at BETWEEN CURRENT_DATE - $2 AND CURRENT_DATE
                 AND
-                  theme = $2
+                  theme = $3
                 AND
-                  level = $3;
+                  level = $4;
                 """,
                 user_id,
+                bot_settings.WEAK_THEMES_ADVICE_INTERVAL,
                 theme,
                 level,
             )

--- a/src/repositories/postgres/advices.py
+++ b/src/repositories/postgres/advices.py
@@ -97,7 +97,7 @@ class AdvicesRepo:
                 WHERE
                   user_id = $1
                 AND
-                  created_at BETWEEN (CURRENT_DATE - $2) AND CURRENT_DATE
+                  created_at BETWEEN (CURRENT_DATE - $2::integer)::date AND CURRENT_DATE
                 AND
                   theme = $3
                 AND

--- a/src/repositories/postgres/advices.py
+++ b/src/repositories/postgres/advices.py
@@ -1,4 +1,5 @@
 import asyncpg
+from settings import bot_settings
 
 
 # done
@@ -85,7 +86,7 @@ class AdvicesRepo:
     async def get_send_advice(self, user_id: int, theme: str, level: int) -> asyncpg.Record | None:
         async with self.pg_pool.acquire() as conn:
             row = await conn.fetchrow(
-                """
+                f"""
                 SELECT
                   id
                 FROM
@@ -95,7 +96,7 @@ class AdvicesRepo:
                 WHERE
                   user_id = $1
                 AND
-                  created_at BETWEEN CURRENT_DATE - 14 AND CURRENT_DATE
+                  created_at BETWEEN CURRENT_DATE - {bot_settings.WEAK_THEMES_ADVICE_INTERVAL} AND CURRENT_DATE
                 AND
                   theme = $2
                 AND

--- a/src/repositories/postgres/advices.py
+++ b/src/repositories/postgres/advices.py
@@ -97,7 +97,7 @@ class AdvicesRepo:
                 WHERE
                   user_id = $1
                 AND
-                  created_at (BETWEEN CURRENT_DATE - $2) AND CURRENT_DATE
+                  created_at BETWEEN (CURRENT_DATE - $2) AND CURRENT_DATE
                 AND
                   theme = $3
                 AND

--- a/src/repositories/postgres/advices.py
+++ b/src/repositories/postgres/advices.py
@@ -97,7 +97,7 @@ class AdvicesRepo:
                 WHERE
                   user_id = $1
                 AND
-                  created_at BETWEEN (CURRENT_DATE - $2::integer) AND CURRENT_DATE
+                  created_at BETWEEN CURRENT_DATE - $2::integer AND CURRENT_DATE
                 AND
                   theme = $3
                 AND

--- a/src/repositories/postgres/advices.py
+++ b/src/repositories/postgres/advices.py
@@ -97,7 +97,7 @@ class AdvicesRepo:
                 WHERE
                   user_id = $1
                 AND
-                  created_at BETWEEN (CURRENT_DATE - $2::integer)::date AND CURRENT_DATE
+                  created_at BETWEEN (CURRENT_DATE - $2::integer) AND CURRENT_DATE
                 AND
                   theme = $3
                 AND

--- a/src/repositories/postgres/advices.py
+++ b/src/repositories/postgres/advices.py
@@ -97,16 +97,16 @@ class AdvicesRepo:
                 WHERE
                   user_id = $1
                 AND
-                  created_at BETWEEN CURRENT_DATE - $4 AND CURRENT_DATE
+                  created_at BETWEEN CURRENT_DATE - $2 AND CURRENT_DATE
                 AND
-                  theme = $2
+                  theme = $3
                 AND
-                  level = $3;
+                  level = $4;
                 """,
                 user_id,
+                bot_settings.WEAK_THEMES_ADVICE_INTERVAL,
                 theme,
                 level,
-                bot_settings.WEAK_THEMES_ADVICE_INTERVAL,
             )
 
         return row

--- a/src/repositories/postgres/advices.py
+++ b/src/repositories/postgres/advices.py
@@ -96,16 +96,16 @@ class AdvicesRepo:
                 WHERE
                   user_id = $1
                 AND
-                  created_at BETWEEN CURRENT_DATE - $2 AND CURRENT_DATE
+                  created_at BETWEEN CURRENT_DATE - $4 AND CURRENT_DATE
                 AND
-                  theme = $3
+                  theme = $2
                 AND
-                  level = $4;
+                  level = $3;
                 """,
                 user_id,
-                bot_settings.WEAK_THEMES_ADVICE_INTERVAL,
                 theme,
                 level,
+                bot_settings.WEAK_THEMES_ADVICE_INTERVAL,
             )
 
         return row

--- a/tests_functional/tasks/test_send_advices.py
+++ b/tests_functional/tasks/test_send_advices.py
@@ -25,7 +25,7 @@ async def test_send_advices_task(pg: asyncpg.Pool, mocker: MockerFixture) -> Non
     user_id_4 = await add_user(pg=pg, username='user_4')
 
     created_at_3 = datetime.utcnow() - timedelta(days=3)
-    created_at_4 = datetime.utcnow() - timedelta(days=15)
+    created_at_4 = datetime.utcnow() - timedelta(days=31)
 
     await add_users_questions(pg=pg, question_id=question_id_1, user_id=user_id_1, is_correct=False)
     await add_users_questions(pg=pg, question_id=question_id_2, user_id=user_id_2, is_correct=False)


### PR DESCRIPTION
Introduces a "WEAK_THEMES_ADVICE_INTERVAL" setting, which allows to manually set the interval (in days) between new advices of weak themes sent by the bot. The constant is imported into src/repositories/postgres/advices.py and embedded into the get_send_advice function's SQL query via $-type placeholder. + Change of a test parameter: 15 -> 31.